### PR TITLE
Feature jplag base code

### DIFF
--- a/src/TutorBot.Cli/Commands/CheckPlagiarismCommand.cs
+++ b/src/TutorBot.Cli/Commands/CheckPlagiarismCommand.cs
@@ -86,15 +86,13 @@ internal class CheckPlagiarismCommand : Command
       var jplagRunArgs = "";
       if (baseCodeOption is not null)
       {
-        jplagRunArgs = string.Format(Constants.JPLAG_RUN_ARGS_BASE_DIR_PREFIX, baseCodeOption);
+        jplagRunArgs = string.Format(Constants.JPLAG_RUN_ARGS_BASE_DIR_PREFIX, baseCodeOption.TrimEnd(['/', '\\']));
       }
       
       jplagRunArgs += string.Format(Constants.JPLAG_RUN_ARGS, language, reportFile, rootDirectory);
       
       
       var javaArgs = $"-jar \"{configuration.JplagJarPath}\" {jplagRunArgs}";
-      
-      Console.WriteLine(javaArgs);
 
       var (result, errorResult, exitCode) = await ProcessHelper.RunProcessAsync(configuration.JavaPath, javaArgs);
 

--- a/src/TutorBot.Cli/Commands/CheckPlagiarismCommand.cs
+++ b/src/TutorBot.Cli/Commands/CheckPlagiarismCommand.cs
@@ -19,8 +19,9 @@ internal class CheckPlagiarismCommand : Command
   private readonly Option<string> languageOption = new("--language") { Description = "language", Aliases = { "-l" } };
   private readonly Option<string> reportFileOption = new("--report-file") { Description = "name of the report file", Aliases = { "-rf" } };
   private readonly Option<bool> refreshOption = new("--refresh") { Description = "redo check although results file exists", Aliases = { "-r" } };
+  private readonly Option<string> baseCodeOption = new("--base-code") { Description = "Path to the template code directory", Aliases = { "-bc" } };
 
-  private async Task HandleAsync(string rootDirectory, string languageOption, string? reportFileOption, bool refreshOption)
+  private async Task HandleAsync(string rootDirectory, string languageOption, string? reportFileOption, bool refreshOption, string? baseCodeOption)
   {
     try
     {
@@ -36,10 +37,16 @@ internal class CheckPlagiarismCommand : Command
 
       string reportFile = reportFileOption ?? $"{rootDirectory}/{Constants.DEFAULT_REPORT_FILE}";
 
+      if (baseCodeOption is not null
+          && !Directory.Exists(baseCodeOption))
+      {
+        throw new DomainException($"Error: Given BaseCode Directory \"{baseCodeOption}\" does not exist.");
+      }
+
       bool resultFileExists;
       if (refreshOption || !File.Exists(reportFile))
       {
-        resultFileExists = await RunJplag(rootDirectory, reportFile, languageOption);
+        resultFileExists = await RunJplag(rootDirectory, reportFile, languageOption, baseCodeOption);
       }
       else
       {
@@ -59,7 +66,7 @@ internal class CheckPlagiarismCommand : Command
     }
   }
 
-  private async Task<bool> RunJplag(string rootDirectory, string reportFile, string languageOption)
+  private async Task<bool> RunJplag(string rootDirectory, string reportFile, string languageOption, string? baseCodeOption)
   {
     try
     {
@@ -76,8 +83,18 @@ internal class CheckPlagiarismCommand : Command
                                   $"       Ensure that the configuration parameter \"{ConfigurationHelper.KEY_JPLAG_JAR_PATH}\" is set appropriately.");
       }
 
-      var jplagRunArgs = string.Format(Constants.JPLAG_RUN_ARGS, language, reportFile, rootDirectory);
+      var jplagRunArgs = "";
+      if (baseCodeOption is not null)
+      {
+        jplagRunArgs = string.Format(Constants.JPLAG_RUN_ARGS_BASE_DIR_PREFIX, baseCodeOption);
+      }
+      
+      jplagRunArgs += string.Format(Constants.JPLAG_RUN_ARGS, language, reportFile, rootDirectory);
+      
+      
       var javaArgs = $"-jar \"{configuration.JplagJarPath}\" {jplagRunArgs}";
+      
+      Console.WriteLine(javaArgs);
 
       var (result, errorResult, exitCode) = await ProcessHelper.RunProcessAsync(configuration.JavaPath, javaArgs);
 
@@ -159,6 +176,8 @@ internal class CheckPlagiarismCommand : Command
 
     refreshOption.DefaultValueFactory = _ => false;
     Options.Add(refreshOption);
+    
+    Options.Add(baseCodeOption);
 
     Aliases.Add("cp");
 
@@ -168,7 +187,8 @@ internal class CheckPlagiarismCommand : Command
       var language = parsedResult.GetRequiredValue(languageOption);
       var reportFile = parsedResult.GetValue(reportFileOption);
       var refresh = parsedResult.GetValue(refreshOption);
-      await HandleAsync(rootDirectory, language, reportFile, refresh);
+      var baseCode = parsedResult.GetValue(baseCodeOption);
+      await HandleAsync(rootDirectory, language, reportFile, refresh, baseCode);
     });
   }
 }

--- a/src/TutorBot.Cli/Constants.cs
+++ b/src/TutorBot.Cli/Constants.cs
@@ -24,6 +24,7 @@ internal static class Constants
   public const int FEEDBACK_PULLREQUEST_ID = 1;
 
   public const string JPLAG_RUN_ARGS = "--language={0} --result-file=\"{1}\" --mode=RUN \"{2}\""; // {0} = language, {1} = report file, {2} = root directory
+  public const string JPLAG_RUN_ARGS_BASE_DIR_PREFIX = "--base-code=\"{0}\" "; // {0} = template directory
   public const string JPLAG_VIEW_ARGS = "--result-file=\"{0}\" --mode=VIEW\""; // {0} = report file
   public const string DEFAULT_REPORT_FILE = "plagiarism-report.jplag";
 


### PR DESCRIPTION
In the SWC Assignments, Students are sometimes given existing code.

To get JPlag to ignore this Code the Parameter for a more accurate similarity score --base-code exists, see https://github.com/jplag/JPlag?tab=readme-ov-file#cli

This small adjustment serves to allow the flag to be added to the check-plagiarism CLI Command

It has been tested in the CLI already, in case the parameter is omitted, the behavior stays the same, in case it is added it validates the existance of the given directory and adds the correct parameter to the JPlag CLI Command