### PR TITLE
Added C as an additional Language Option for the CheckPlagiarism Command and documented the new Base-Code Command from the last PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,14 @@ TutorBot offers the following range of commands:
   directory. This file contains multiple JSON files that display the results
   of the plagiarism check. These results can be analyzed using the `view-plagiarism-report` command. 
   ```shell
-  gh tutorbot check-plagiarism <root-directory> [--language (cpp|java)] [--report-file <report-file>] [--refresh]
+  gh tutorbot check-plagiarism <root-directory> [--language (cpp|java|c)] [--report-file <report-file>] [--refresh] [--base-code <base-code-directory>]
   ```
   + `root-directory` is the path of the directory containing all submissions.
   + `--language` specifies the programming language of the submissions.
   + `--report-file` specifies the base name of the report file.
   + `--refresh` forces a plagiarism check, even if the results file already
     exists.
+  + `--base-code` is the path to the directory containing the template of the submission. It can be used to ignore already provided code from being recognized as plagiarism
 
 * View plagiarism report: Launches a local web server to display the results of
   a plagiarism check in your browser. This command opens the JPlag report

--- a/src/TutorBot.Cli/Commands/CheckPlagiarismCommand.cs
+++ b/src/TutorBot.Cli/Commands/CheckPlagiarismCommand.cs
@@ -21,6 +21,7 @@ internal class CheckPlagiarismCommand : Command
   private readonly Option<bool> refreshOption = new("--refresh") { Description = "redo check although results file exists", Aliases = { "-r" } };
   private readonly Option<string> baseCodeOption = new("--base-code") { Description = "Path to the template code directory", Aliases = { "-bc" } };
 
+  private readonly String[] allowedLangs = ["cpp", "java", "c"];
   private async Task HandleAsync(string rootDirectory, string languageOption, string? reportFileOption, bool refreshOption, string? baseCodeOption)
   {
     try
@@ -30,9 +31,9 @@ internal class CheckPlagiarismCommand : Command
         throw new DomainException($"Error: Root directory \"{rootDirectory}\" does not exist. Clone assignment first.");
       }
 
-      if (languageOption != "cpp" && languageOption != "java")
+      if (!allowedLangs.Contains(languageOption.ToLower()))
       {
-        throw new DomainException($"Error: Unknown language \"{languageOption}\". Allowed values are 'cpp' and 'java'.");
+        throw new DomainException($"Error: Unknown language \"{languageOption}\". Allowed values are the following: " + string.Join(", ", allowedLangs));
       }
 
       string reportFile = reportFileOption ?? $"{rootDirectory}/{Constants.DEFAULT_REPORT_FILE}";
@@ -74,6 +75,7 @@ internal class CheckPlagiarismCommand : Command
       {
         "cpp" => "cpp",
         "java" => "java",
+        "c" => "c",
         _ => throw new DomainException($"Error: Unknown language \"{languageOption}\"")
       };
 
@@ -167,7 +169,7 @@ internal class CheckPlagiarismCommand : Command
     Add(rootDirectoryArgument);
 
     languageOption.DefaultValueFactory = _ => "java";
-    languageOption.AcceptOnlyFromAmong("cpp", "java");
+    languageOption.AcceptOnlyFromAmong(allowedLangs);
     Options.Add(languageOption);
 
     Options.Add(reportFileOption);


### PR DESCRIPTION
JPlag does not seem to properly parse C files with the CPP language flag, therefore the supported C flag was added to the language option.
In addition the available languages are now saved in an array, should they ever need to be extended further

Since I was already at it, I also added the documentation for the Base-Code Option with the new Lang Option value so everything which was added by me is documented properly